### PR TITLE
fix(webhooks): output source code hash

### DIFF
--- a/webhooks/change/terraform-aws-jira-webhook/terraform/lambda.tf
+++ b/webhooks/change/terraform-aws-jira-webhook/terraform/lambda.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = local.name
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.function_archive.output_path
-  source_code_hash = data.archive_file.function_archive.output_sha
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
   memory_size      = local.lambda_memory
   handler          = "index.handle"
   runtime          = "nodejs12.x"

--- a/webhooks/change/terraform-aws-okta-profile-webhook/terraform/lambda.tf
+++ b/webhooks/change/terraform-aws-okta-profile-webhook/terraform/lambda.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = local.name
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.function_archive.output_path
-  source_code_hash = filesha256(data.archive_file.function_archive.output_path)
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
   memory_size      = local.lambda_memory
   handler          = "index.handle"
   runtime          = "nodejs14.x"

--- a/webhooks/change/terraform-aws-okta-webhook/terraform/lambda.tf
+++ b/webhooks/change/terraform-aws-okta-webhook/terraform/lambda.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = local.name
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.function_archive.output_path
-  source_code_hash = filesha256(data.archive_file.function_archive.output_path)
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
   memory_size      = local.lambda_memory
   handler          = "index.handle"
   runtime          = "nodejs14.x"

--- a/webhooks/pull/terraform-aws-custom-pull-webhook/terraform/lambda.tf
+++ b/webhooks/pull/terraform-aws-custom-pull-webhook/terraform/lambda.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = local.name
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.function_archive.output_path
-  source_code_hash = filesha256("${path.module}/../dist/function.zip")
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
   memory_size      = local.lambda_memory
   handler          = "index.handle"
   runtime          = "nodejs12.x"

--- a/webhooks/pull/terraform-aws-okta-pull-webhook/terraform/lambda.tf
+++ b/webhooks/pull/terraform-aws-okta-pull-webhook/terraform/lambda.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = local.name
   role             = aws_iam_role.lambda_role.arn
   filename         = data.archive_file.function_archive.output_path
-  source_code_hash = filesha256(data.archive_file.function_archive.output_path)
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
   memory_size      = local.lambda_memory
   handler          = "index.handle"
   runtime          = "nodejs14.x"


### PR DESCRIPTION
Fix for outputting the correct source code hash for all AWS terraform modules