### PR TITLE
add(webhooks/pull): terraform-(aws/gcloud)-okta-pull-webhook [ID-1010]

### DIFF
--- a/webhooks/pull/terraform-aws-okta-pull-webhook/src/index.ts
+++ b/webhooks/pull/terraform-aws-okta-pull-webhook/src/index.ts
@@ -123,6 +123,7 @@ async function pullGroups(): Promise<Indent.Resource[]> {
         oktaId: group.id,
         description: group.profile.description || '',
         timestamp,
+        oktaGroupType: group.type,
       },
     }),
   })

--- a/webhooks/pull/terraform-aws-okta-pull-webhook/terraform/config/example.tfvars
+++ b/webhooks/pull/terraform-aws-okta-pull-webhook/terraform/config/example.tfvars
@@ -17,5 +17,4 @@ okta_client_id = ""
 
 # Okta Private Key (Optional) - This is an RSA private key used to generate a signed Bearer token for OAuth 2.0 access
 okta_private_key = <<EOT
-
 EOT

--- a/webhooks/pull/terraform-gcloud-okta-pull-webhook/src/index.ts
+++ b/webhooks/pull/terraform-gcloud-okta-pull-webhook/src/index.ts
@@ -117,6 +117,7 @@ async function pullGroups(): Promise<Resource[]> {
         oktaId: group.id,
         description: group.profile.description || '',
         timestamp,
+        oktaGroupType: group.type,
       },
     }),
   })
@@ -185,7 +186,6 @@ async function pullUsers(): Promise<Resource[]> {
           },
         }),
       })
-
   const slackUserResources =
     appUserResources.length > 0
       ? appUserResources

--- a/webhooks/pull/terraform-gcloud-okta-pull-webhook/terraform/main.tf
+++ b/webhooks/pull/terraform-gcloud-okta-pull-webhook/terraform/main.tf
@@ -23,5 +23,6 @@ module "google-github-teams" {
     OKTA_SLACK_APP_ID     = var.okta_slack_app_id
     OKTA_CLIENT_ID        = var.okta_client_id
     OKTA_PRIVATE_KEY      = var.okta_private_key
+    OKTA_SLACK_APP_ID     = var.okta_slack_app_id
   }
 }


### PR DESCRIPTION
Adds oktaGroupType
Adds OKTA_SLACK_APP_ID as optional configuration for users who integrate Slack and Okta